### PR TITLE
feat: Sprint 2 (Day 4-6) - Frontend UI and WebSocket Backend Implementation

### DIFF
--- a/backend/lambda/websocket-handler/connection-manager.js
+++ b/backend/lambda/websocket-handler/connection-manager.js
@@ -3,8 +3,8 @@
  * WebSocket接続の管理とDynamoDBへの永続化を担当
  */
 
-const dynamodbClient = require('../shared/dynamodb-client');
-const Logger = require('../shared/logger');
+const dynamodbClient = require('./shared/dynamodb-client');
+const Logger = require('./shared/logger');
 
 class ConnectionManager {
   constructor() {

--- a/backend/lambda/websocket-handler/index.js
+++ b/backend/lambda/websocket-handler/index.js
@@ -6,7 +6,7 @@
 
 const ConnectionManager = require('./connection-manager');
 const MessageRouter = require('./message-router');
-const Logger = require('../shared/logger');
+const Logger = require('./shared/logger');
 
 // グローバルインスタンス（Lambda実行環境での再利用）
 let connectionManager;

--- a/backend/lambda/websocket-handler/message-router.js
+++ b/backend/lambda/websocket-handler/message-router.js
@@ -6,8 +6,8 @@
 const { ApiGatewayManagementApiClient, PostToConnectionCommand } = require('@aws-sdk/client-apigatewaymanagementapi');
 const { TranscribeStreamingClient, StartStreamTranscriptionCommand } = require('@aws-sdk/client-transcribe-streaming');
 const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3');
-const Logger = require('../shared/logger');
-const dynamodbClient = require('../shared/dynamodb-client');
+const Logger = require('./shared/logger');
+const dynamodbClient = require('./shared/dynamodb-client');
 
 class MessageRouter {
   constructor(endpoint) {

--- a/backend/lambda/websocket-handler/shared/dynamodb-client.js
+++ b/backend/lambda/websocket-handler/shared/dynamodb-client.js
@@ -1,0 +1,213 @@
+/**
+ * VTS DynamoDB Client
+ * DynamoDBへのアクセスを管理し、リトライ機構を提供
+ */
+
+const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
+const { DynamoDBDocumentClient, PutCommand, GetCommand, DeleteCommand, QueryCommand, UpdateCommand, BatchWriteCommand } = require('@aws-sdk/lib-dynamodb');
+const Logger = require('./logger');
+
+class DynamoDBManager {
+  constructor() {
+    this.logger = new Logger({ component: 'DynamoDBManager' });
+    
+    // DynamoDB Clientの初期化
+    const client = new DynamoDBClient({
+      region: process.env.AWS_REGION || 'ap-northeast-1',
+      maxAttempts: 3,
+      retryMode: 'adaptive'
+    });
+
+    // DocumentClientでラップ（自動的にマーシャリング/アンマーシャリング）
+    this.docClient = DynamoDBDocumentClient.from(client, {
+      marshallOptions: {
+        removeUndefinedValues: true,
+        convertEmptyValues: false
+      }
+    });
+  }
+
+  /**
+   * アイテムを保存
+   * @param {string} tableName - テーブル名
+   * @param {Object} item - 保存するアイテム
+   * @returns {Promise<Object>} - 保存結果
+   */
+  async putItem(tableName, item) {
+    const params = {
+      TableName: tableName,
+      Item: item
+    };
+
+    try {
+      this.logger.debug('DynamoDB putItem', { tableName, item });
+      const result = await this.docClient.send(new PutCommand(params));
+      this.logger.info('Item saved successfully', { tableName, itemId: item.id || item.connectionId });
+      return result;
+    } catch (error) {
+      this.logger.error('Failed to save item to DynamoDB', error);
+      throw error;
+    }
+  }
+
+  /**
+   * アイテムを取得
+   * @param {string} tableName - テーブル名
+   * @param {Object} key - プライマリキー
+   * @returns {Promise<Object|null>} - 取得したアイテム
+   */
+  async getItem(tableName, key) {
+    const params = {
+      TableName: tableName,
+      Key: key
+    };
+
+    try {
+      this.logger.debug('DynamoDB getItem', { tableName, key });
+      const result = await this.docClient.send(new GetCommand(params));
+      if (result.Item) {
+        this.logger.info('Item retrieved successfully', { tableName, key });
+        return result.Item;
+      }
+      this.logger.info('Item not found', { tableName, key });
+      return null;
+    } catch (error) {
+      this.logger.error('Failed to get item from DynamoDB', error);
+      throw error;
+    }
+  }
+
+  /**
+   * アイテムを削除
+   * @param {string} tableName - テーブル名
+   * @param {Object} key - プライマリキー
+   * @returns {Promise<Object>} - 削除結果
+   */
+  async deleteItem(tableName, key) {
+    const params = {
+      TableName: tableName,
+      Key: key
+    };
+
+    try {
+      this.logger.debug('DynamoDB deleteItem', { tableName, key });
+      const result = await this.docClient.send(new DeleteCommand(params));
+      this.logger.info('Item deleted successfully', { tableName, key });
+      return result;
+    } catch (error) {
+      this.logger.error('Failed to delete item from DynamoDB', error);
+      throw error;
+    }
+  }
+
+  /**
+   * アイテムを更新
+   * @param {string} tableName - テーブル名
+   * @param {Object} key - プライマリキー
+   * @param {Object} updates - 更新内容
+   * @returns {Promise<Object>} - 更新結果
+   */
+  async updateItem(tableName, key, updates) {
+    // 更新式を動的に構築
+    const updateExpression = [];
+    const expressionAttributeNames = {};
+    const expressionAttributeValues = {};
+
+    Object.keys(updates).forEach((field, index) => {
+      const placeholder = `#field${index}`;
+      const valuePlaceholder = `:value${index}`;
+      
+      updateExpression.push(`${placeholder} = ${valuePlaceholder}`);
+      expressionAttributeNames[placeholder] = field;
+      expressionAttributeValues[valuePlaceholder] = updates[field];
+    });
+
+    const params = {
+      TableName: tableName,
+      Key: key,
+      UpdateExpression: `SET ${updateExpression.join(', ')}`,
+      ExpressionAttributeNames: expressionAttributeNames,
+      ExpressionAttributeValues: expressionAttributeValues,
+      ReturnValues: 'ALL_NEW'
+    };
+
+    try {
+      this.logger.debug('DynamoDB updateItem', { tableName, key, updates });
+      const result = await this.docClient.send(new UpdateCommand(params));
+      this.logger.info('Item updated successfully', { tableName, key });
+      return result.Attributes;
+    } catch (error) {
+      this.logger.error('Failed to update item in DynamoDB', error);
+      throw error;
+    }
+  }
+
+  /**
+   * クエリ実行
+   * @param {string} tableName - テーブル名
+   * @param {Object} queryParams - クエリパラメータ
+   * @returns {Promise<Array>} - クエリ結果
+   */
+  async query(tableName, queryParams) {
+    const params = {
+      TableName: tableName,
+      ...queryParams
+    };
+
+    try {
+      this.logger.debug('DynamoDB query', { tableName, queryParams });
+      const result = await this.docClient.send(new QueryCommand(params));
+      this.logger.info('Query executed successfully', { 
+        tableName, 
+        itemCount: result.Items?.length || 0 
+      });
+      return result.Items || [];
+    } catch (error) {
+      this.logger.error('Failed to query DynamoDB', error);
+      throw error;
+    }
+  }
+
+  /**
+   * バッチ書き込み（複数アイテムの一括保存）
+   * @param {string} tableName - テーブル名
+   * @param {Array} items - 保存するアイテムの配列
+   * @returns {Promise<Object>} - 保存結果
+   */
+  async batchWrite(tableName, items) {
+    // 25個ずつのバッチに分割（DynamoDBの制限）
+    const chunks = [];
+    for (let i = 0; i < items.length; i += 25) {
+      chunks.push(items.slice(i, i + 25));
+    }
+
+    const results = [];
+    for (const chunk of chunks) {
+      const params = {
+        RequestItems: {
+          [tableName]: chunk.map(item => ({
+            PutRequest: { Item: item }
+          }))
+        }
+      };
+
+      try {
+        const result = await this.docClient.send(new BatchWriteCommand(params));
+        results.push(result);
+      } catch (error) {
+        this.logger.error('Batch write failed', error);
+        throw error;
+      }
+    }
+
+    this.logger.info('Batch write completed', { 
+      tableName, 
+      totalItems: items.length,
+      batches: chunks.length 
+    });
+    return results;
+  }
+}
+
+// シングルトンインスタンスをエクスポート
+module.exports = new DynamoDBManager();

--- a/backend/lambda/websocket-handler/shared/logger.js
+++ b/backend/lambda/websocket-handler/shared/logger.js
@@ -1,0 +1,99 @@
+/**
+ * VTS Logger Utility
+ * CloudWatch Logsへの構造化ログ出力を提供
+ */
+
+const LOG_LEVELS = {
+  ERROR: 'ERROR',
+  WARN: 'WARN',
+  INFO: 'INFO',
+  DEBUG: 'DEBUG'
+};
+
+class Logger {
+  constructor(context = {}) {
+    this.context = context;
+    this.logLevel = process.env.LOG_LEVEL || 'INFO';
+  }
+
+  _shouldLog(level) {
+    const levels = ['ERROR', 'WARN', 'INFO', 'DEBUG'];
+    const currentLevelIndex = levels.indexOf(this.logLevel);
+    const requestedLevelIndex = levels.indexOf(level);
+    return requestedLevelIndex <= currentLevelIndex;
+  }
+
+  _formatLog(level, message, data = {}) {
+    const log = {
+      timestamp: new Date().toISOString(),
+      level,
+      message,
+      ...this.context,
+      ...data
+    };
+
+    // CloudWatch Logsに適したJSON形式で出力
+    return JSON.stringify(log);
+  }
+
+  error(message, error = null) {
+    if (this._shouldLog(LOG_LEVELS.ERROR)) {
+      const data = error ? {
+        errorMessage: error.message,
+        errorStack: error.stack,
+        errorName: error.name
+      } : {};
+      console.error(this._formatLog(LOG_LEVELS.ERROR, message, data));
+    }
+  }
+
+  warn(message, data = {}) {
+    if (this._shouldLog(LOG_LEVELS.WARN)) {
+      console.warn(this._formatLog(LOG_LEVELS.WARN, message, data));
+    }
+  }
+
+  info(message, data = {}) {
+    if (this._shouldLog(LOG_LEVELS.INFO)) {
+      console.info(this._formatLog(LOG_LEVELS.INFO, message, data));
+    }
+  }
+
+  debug(message, data = {}) {
+    if (this._shouldLog(LOG_LEVELS.DEBUG)) {
+      console.debug(this._formatLog(LOG_LEVELS.DEBUG, message, data));
+    }
+  }
+
+  // 監査ログ用の特別なメソッド
+  audit(action, data = {}) {
+    const auditLog = {
+      timestamp: new Date().toISOString(),
+      level: 'AUDIT',
+      action,
+      ...this.context,
+      ...data
+    };
+    console.info(JSON.stringify(auditLog));
+  }
+
+  // メトリクス記録用
+  metric(metricName, value, unit = 'Count', dimensions = {}) {
+    const metric = {
+      timestamp: new Date().toISOString(),
+      level: 'METRIC',
+      metricName,
+      value,
+      unit,
+      dimensions: { ...this.context, ...dimensions }
+    };
+    console.info(JSON.stringify(metric));
+  }
+
+  // 子ロガーを作成（追加のコンテキストを持つ）
+  child(additionalContext) {
+    return new Logger({ ...this.context, ...additionalContext });
+  }
+}
+
+module.exports = Logger;

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,4 +1,5 @@
 # Development environment variables
-VITE_WS_URL=ws://localhost:8080
-VITE_API_ENV=development
+# For AWS testing, use the real WebSocket endpoint
+VITE_WS_URL=wss://kaqn2r1p8i.execute-api.ap-northeast-1.amazonaws.com/prod
+VITE_API_ENV=aws-test
 VITE_DEBUG=true

--- a/frontend/test-aws-ws.js
+++ b/frontend/test-aws-ws.js
@@ -1,0 +1,52 @@
+import WebSocket from 'ws';
+
+const WS_URL = 'wss://kaqn2r1p8i.execute-api.ap-northeast-1.amazonaws.com/prod';
+
+console.log('🔌 Connecting to AWS WebSocket:', WS_URL);
+
+const ws = new WebSocket(WS_URL);
+
+ws.on('open', () => {
+  console.log('✅ Connected to AWS WebSocket!');
+  
+  // Send ping
+  const pingMessage = JSON.stringify({
+    action: 'ping',
+    payload: {},
+    timestamp: new Date().toISOString()
+  });
+  
+  console.log('📤 Sending ping:', pingMessage);
+  ws.send(pingMessage);
+  
+  // Test audio data
+  setTimeout(() => {
+    console.log('📤 Sending test audio data...');
+    ws.send(JSON.stringify({
+      action: 'audioData',
+      payload: { 
+        audio: 'dGVzdCBhdWRpbyBkYXRh' // "test audio data" in base64
+      },
+      timestamp: new Date().toISOString()
+    }));
+  }, 1000);
+  
+  // Close after 5 seconds to see the transcription response
+  setTimeout(() => {
+    console.log('Closing connection...');
+    ws.close();
+  }, 5000);
+});
+
+ws.on('message', (data) => {
+  console.log('📨 Received:', JSON.parse(data.toString()));
+});
+
+ws.on('error', (error) => {
+  console.error('❌ WebSocket error:', error);
+});
+
+ws.on('close', () => {
+  console.log('👋 Connection closed');
+  process.exit(0);
+});


### PR DESCRIPTION
## Summary
Sprint 2の実装が完了しました。フロントエンドUIの構築とWebSocketバックエンドの実装により、MVP段階での音声通信基盤が確立されました。

### 🎯 Sprint 2 成果物
- ✅ **Day 4-5**: React/TypeScript/Tailwind CSSによるフロントエンド実装
- ✅ **Day 6**: Lambda WebSocketハンドラーとAWS統合

### 🚀 主な機能実装
#### Frontend
- WebSocket接続サービス（自動再接続機能付き）
- 音声録音機能（Web Audio API）
- リアルタイム音声レベル表示
- 文字起こし結果表示UI
- AI応答パネル
- 接続ステータス管理

#### Backend
- WebSocketメッセージルーティング
- 接続管理（DynamoDB）
- モック文字起こしレスポンス（MVP用）
- CloudWatch統合ロギング

### 📊 技術スタック
- **Frontend**: React 18, TypeScript, Vite, Tailwind CSS v3
- **Backend**: Node.js 20, AWS Lambda, API Gateway WebSocket
- **Infrastructure**: AWS CDK v2
- **Data**: DynamoDB, S3, CloudWatch Logs

## Test Plan
### ✅ 完了済みテスト
- [x] ローカル開発環境での動作確認
- [x] モックWebSocketサーバーでの接続テスト
- [x] AWS本番環境へのWebSocket接続確認
- [x] メッセージ送受信の動作確認
- [x] CloudWatch Logsでの監視確認

### 📝 追加テストが必要な項目
- [ ] 長時間接続の安定性テスト
- [ ] 複数同時接続のスケーラビリティテスト
- [ ] エラーハンドリングのエッジケーステスト

## Screenshots/Demo
### WebSocket接続成功
```
🔌 Connecting to AWS WebSocket: wss://kaqn2r1p8i.execute-api.ap-northeast-1.amazonaws.com/prod
✅ Connected to AWS WebSocket!
📤 Sending ping: {"action":"ping","payload":{},"timestamp":"2025-01-13T..."}
📨 Received: {"type":"pong","timestamp":"2025-01-13T..."}
📤 Sending test audio data...
📨 Received: {"type":"transcription","payload":{"transcriptText":"本船は東京湾入口を通過中",...}}
```

## Next Steps (Sprint 3)
- Day 7: Amazon Transcribe Streaming実装
- Day 8: Amazon Bedrock統合
- Day 9: エンドツーエンドテストとデモ準備

## Breaking Changes
なし

## Dependencies Added
- Frontend: `reconnecting-websocket`, `react-icons`
- Backend: AWS SDK v3 clients

## Deployment Notes
CDKデプロイ済み。WebSocket APIエンドポイントが利用可能です。

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - 開始/停止を「status」通知で配信。部分/最終のモック文字起こしを段階的に送信。音声のS3保存を環境変数で任意化。
- 変更
  - 言語指定の互換性拡大（languageCode/language を許容）。音声ペイロードの受理範囲拡大（audio/audioData、既定のsessionId/sequenceNumber）。
- 改善
  - セッション停止時の耐障害性向上（セッション不在でも正常応答）。ログの整備。
- チョア
  - 開発用フロントエンドのWSエンドポイントをAWSに更新。動作確認スクリプトを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->